### PR TITLE
Remove test module that masked test suite package; document how to run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ If you don't already have one:
 python manage.py createsuperuser
 ```
 
+## Testing
+
+Run all tests for all Django Apps associated with this Django Project:
+
+```sh
+python manage.py test
+```
 
 [adminlte2]: https://django-adminlte2.readthedocs.io/en/latest/ 
 [conda]: https://docs.conda.io/en/latest/

--- a/rse/tests.py
+++ b/rse/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.


### PR DESCRIPTION
We're using the second option listed under 'Structure' [here](https://realpython.com/testing-in-django-part-1-best-practices-and-examples/#structure) so shouldn't also use the first as AFAICT they're mutually exclusive. 