### PR TITLE
Fix: project schedule should be 'rejected' when the project status is 'rejected'

### DIFF
--- a/rse/models.py
+++ b/rse/models.py
@@ -680,6 +680,7 @@ class Project(PolymorphicModel):
         ('Active', 'Active'),
         ('Completed', 'Completed'),
         ('Scheduled', 'Scheduled'),
+        ('Rejected', 'Rejected'),
     )
 
     @property
@@ -779,6 +780,7 @@ class Project(PolymorphicModel):
 
     @property
     def get_schedule_display(self) -> str:
+        """ Schedule should be rejected if the status is rejected. """
         if self.status == Project.REJECTED:
             return Project.SCHEDULE_REJECTED
         

--- a/rse/models.py
+++ b/rse/models.py
@@ -675,6 +675,7 @@ class Project(PolymorphicModel):
     SCHEDULE_ACTIVE = "Active"
     SCHEDULE_COMPLETED = "Completed"
     SCHEDULE_SCHEDULED = "Scheduled"
+    SCHEDULE_REJECTED = "Rejected"
     SCHEDULE_CHOICES_TEXT_KEYS = (
         ('Active', 'Active'),
         ('Completed', 'Completed'),
@@ -778,6 +779,9 @@ class Project(PolymorphicModel):
 
     @property
     def get_schedule_display(self) -> str:
+        if self.status == Project.REJECTED:
+            return Project.SCHEDULE_REJECTED
+        
         now = timezone.now().date()
         if now < self.start:
             return Project.SCHEDULE_SCHEDULED


### PR DESCRIPTION
- Modified the project model to check for project status
- Added 'Rejected' to the filter

Close #210.